### PR TITLE
Fix dot bug

### DIFF
--- a/R/scales.R
+++ b/R/scales.R
@@ -2,10 +2,12 @@
 #' @export
 set_scales <- function(., ...) {
     scales <- lazy_dots(...)
-    if (is.null(names(scales))) {
+    scale_names <- names(scales)
+    
+    if (is.null(scale_names) || any(scale_names == "")) {
         stop("scales must be named", call. = FALSE)
     }
-    for (scale in names(scales)) {
+    for (scale in scale_names) {
         scale_type <- as.character(scales[[scale]]$expr)[1]
         scale_name <- paste0("scale_", scale, '_', scale_type)
         scale_fun <- tryCatch(get(scale_name), error = function(e) {

--- a/R/scales.R
+++ b/R/scales.R
@@ -4,7 +4,7 @@ set_scales <- function(., ...) {
     scales <- lazy_dots(...)
     scale_names <- names(scales)
     
-    if (is.null(scale_names) || any(scale_names == "")) {
+    if (any(scale_names == "")) {
         stop("scales must be named", call. = FALSE)
     }
     for (scale in scale_names) {


### PR DESCRIPTION
lazy_dots doesn't set names(...) to NULL if there are no names; instead, they're empty strings. And even if they were NULL, a _partially_ named list wouldn't trigger the is.null check. Accordingly the error handler in set_scales won't actually trigger for the case it's intended to protect against (unnamed scales)

This patch changes the check for unnamed scales to look for a name of "", instead of NULL, and to check for _any_ ... element having that name, and throw an error if even one shows up.

Also it assigns names(scales) because you were using that multiple times, and so it gets an object.
